### PR TITLE
Update  for later laravel versions

### DIFF
--- a/src/Components/ScriptComponent.php
+++ b/src/Components/ScriptComponent.php
@@ -29,7 +29,7 @@ class ScriptComponent extends Component
      *
      * @var Factory
      */
-    public $factory;
+    public $scriptFactory;
 
     /**
      * Create new StyleComponent instance.
@@ -41,7 +41,7 @@ class ScriptComponent extends Component
     public function __construct(Factory $factory, $lang = 'css')
     {
         $this->lang = $lang;
-        $this->factory = $factory;
+        $this->scriptFactory = $factory;
 
         $this->makeScript();
     }
@@ -59,7 +59,7 @@ class ScriptComponent extends Component
             return;
         }
 
-        $this->script = $this->factory->make($path);
+        $this->script = $this->scriptFactory->make($path);
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,7 +9,7 @@ class Factory
     /**
      * Style stack.
      *
-     * @var string
+     * @var array
      */
     protected $stack = [];
 
@@ -23,7 +23,7 @@ class Factory
     /**
      * Engine resolver.
      *
-     * @var \BladeScript\Contracts\Engine
+     * @var \BladeScript\Contracts\ScriptEngine
      */
     protected $engine;
 


### PR DESCRIPTION
This change will avoid a naming conflict from the extended component class, in later laravel versions (9 and up).